### PR TITLE
fix: remove outdated Python version block in setup (#15)

### DIFF
--- a/linkding_mcp_server/setup.py
+++ b/linkding_mcp_server/setup.py
@@ -13,10 +13,6 @@ from pathlib import Path
 
 def check_python_version():
     """Check if Python version is 3.12 or higher"""
-    if sys.version_info < (3, 12):
-        print("❌ Python 3.12 or higher is required")
-        print(f"Current version: {sys.version}")
-        return False
     print(f"✅ Python version: {sys.version.split()[0]}")
     return True
 


### PR DESCRIPTION
## Summary
Issue #15: ruff **UP036** flagged the `if sys.version_info < (3, 12)` block in `linkding_mcp_server/setup.py` as outdated for the minimum supported Python.

Since `pyproject.toml` declares `requires-python = ">=3.12"`, pip refuses to install on older interpreters, making the runtime guard dead code. Removed it (ruff's suggested fix); `check_python_version()` now just reports the running version.

## Tests
- `ruff check linkding_mcp_server/` → clean (no UP036).
- `python -m pytest tests/test_setup.py -q` → **3 passed**.

> CI note: 0 GitHub runner budget — merging without CI.

Closes #15