### PR TITLE
chore: migrate ruff config to [tool.ruff.lint] (#7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ target-version = ["py312"]
 [tool.ruff]
 line-length = 120
 target-version = "py312"
+
+[tool.ruff.lint]
 select = ["E", "F", "B", "I", "N", "UP", "C90"]
 ignore = ["E501"]
 


### PR DESCRIPTION
## Summary
Issue #7: ruff emitted a deprecation warning because `select`/`ignore` were under the top-level `[tool.ruff]` table.

Moved them into `[tool.ruff.lint]` (the modern location). `line-length` and `target-version` stay at the top level where they belong.

## Tests
- `ruff check linkding_mcp_server/` → **All checks passed!** (no deprecation warning).
- `python -m pytest -q` → **80 passed**.

> CI note: 0 GitHub runner budget — merging without CI.

Closes #7