### PR TITLE
refactor: replace settings singleton with dependency injection (#5)

### DIFF
--- a/linkding_mcp_server/config.py
+++ b/linkding_mcp_server/config.py
@@ -100,21 +100,3 @@ class Settings(BaseSettings):
     def get_log_level_int(self) -> int:
         """Get log level as integer for tenacity compatibility"""
         return getattr(logging, self.log_level, logging.INFO)
-
-
-# Singleton instance
-_settings: Settings | None = None
-
-
-def get_settings() -> Settings:
-    """Get or create settings instance"""
-    global _settings
-    if _settings is None:
-        _settings = Settings()
-    return _settings
-
-
-def reset_settings() -> None:
-    """Reset settings singleton (useful for testing)"""
-    global _settings
-    _settings = None

--- a/linkding_mcp_server/server.py
+++ b/linkding_mcp_server/server.py
@@ -11,7 +11,7 @@ from importlib.metadata import version as pkg_version
 
 import structlog
 
-from linkding_mcp_server.config import get_settings
+from linkding_mcp_server.config import Settings
 from linkding_mcp_server.tools import create_mcp_server
 
 try:
@@ -54,8 +54,8 @@ def configure_logging(settings):
 def main():
     """Main entry point for the server"""
     try:
-        # Load settings
-        settings = get_settings()
+        # Load settings (constructed explicitly; no global singleton)
+        settings = Settings()
 
         # Configure logging
         configure_logging(settings)
@@ -71,8 +71,8 @@ def main():
             destructive_actions=settings.enable_destructive_actions,
         )
 
-        # Create MCP server
-        mcp = create_mcp_server()
+        # Create MCP server with explicitly injected settings
+        mcp = create_mcp_server(settings)
 
         # Run the server
         logger.info("server_ready")

--- a/linkding_mcp_server/tools.py
+++ b/linkding_mcp_server/tools.py
@@ -4,7 +4,7 @@ import structlog
 from fastmcp import FastMCP
 
 from .client import LinkDingClient, LinkDingError
-from .config import get_settings
+from .config import Settings
 from .models import BookmarkCreate, BookmarkUpdate, SearchParams
 
 # Configure structured logging
@@ -490,11 +490,15 @@ def register_tools(mcp: FastMCP, settings) -> None:
     mcp.tool(_build_list_bookmarks_by_tag(settings, search_bookmarks))
 
 
-def create_mcp_server() -> FastMCP:
-    """Create and configure the MCP server with all tools"""
-    # Get settings lazily when server is created
-    settings = get_settings()
+def create_mcp_server(settings: Settings) -> FastMCP:
+    """Create and configure the MCP server with all tools.
 
+    Args:
+        settings: Runtime configuration injected by the caller.
+
+    Returns:
+        A configured FastMCP server with all tools registered.
+    """
     mcp = FastMCP(
         name="LinkDing MCP Server",
         instructions="""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,15 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from linkding_mcp_server.config import Settings, get_settings, reset_settings
-
-
-@pytest.fixture(autouse=True)
-def reset_settings_singleton():
-    """Reset settings singleton before and after each test"""
-    reset_settings()
-    yield
-    reset_settings()
+from linkding_mcp_server.config import Settings
 
 
 class TestSettings:
@@ -288,19 +280,29 @@ class TestSSLEnvVars:
         assert settings.ssl_cert_path is None
 
 
-class TestGetSettings:
-    """Tests for get_settings singleton"""
+class TestDependencyInjection:
+    """Settings are constructed explicitly; there is no global singleton."""
 
-    def test_singleton_pattern(self, monkeypatch):
-        """Test that get_settings returns the same instance"""
-        monkeypatch.setenv("LINKDING_API_TOKEN", "singleton_token")
+    def test_no_global_settings_accessor(self):
+        """The removed singleton helpers must not be importable."""
+        import linkding_mcp_server.config as config
 
-        settings1 = get_settings()
-        settings2 = get_settings()
-        assert settings1 is settings2
+        assert not hasattr(config, "get_settings")
+        assert not hasattr(config, "reset_settings")
+        assert not hasattr(config, "_settings")
 
-    def test_settings_initialization(self, monkeypatch):
-        """Test settings initialization from environment"""
-        monkeypatch.setenv("LINKDING_API_TOKEN", "singleton_token")
-        settings = get_settings()
-        assert settings.linkding_api_token == "singleton_token"
+    def test_each_instance_is_independent(self, monkeypatch):
+        """Constructing Settings twice yields distinct, isolated instances."""
+        monkeypatch.setenv("LINKDING_API_TOKEN", "di_token")
+
+        first = Settings()
+        second = Settings()
+        assert first is not second
+        assert first.linkding_api_token == "di_token"
+
+    def test_explicit_values_override_environment(self, monkeypatch):
+        """Explicit constructor args do not depend on any shared state."""
+        monkeypatch.setenv("LINKDING_API_TOKEN", "env_token")
+
+        settings = Settings(linkding_api_token="explicit_token")
+        assert settings.linkding_api_token == "explicit_token"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,7 +6,7 @@ import pytest
 from fastmcp import Client
 
 from linkding_mcp_server import tools
-from linkding_mcp_server.config import reset_settings
+from linkding_mcp_server.config import Settings
 from linkding_mcp_server.models import Tag, TagList
 from linkding_mcp_server.tools import create_mcp_server
 
@@ -24,14 +24,10 @@ EXPECTED_TOOLS = {
 }
 
 
-@pytest.fixture(autouse=True)
-def _env(monkeypatch):
-    """Provide a valid token so get_settings() succeeds, and reset the singleton."""
-    monkeypatch.setenv("LINKDING_API_TOKEN", "test_token_12345")
-    monkeypatch.delenv("LINKDING_ENABLE_DESTRUCTIVE_ACTIONS", raising=False)
-    reset_settings()
-    yield
-    reset_settings()
+@pytest.fixture
+def settings():
+    """Settings injected explicitly into create_mcp_server (no global singleton)."""
+    return Settings(linkding_api_token="test_token_12345", enable_destructive_actions=False)
 
 
 def _patch_client(monkeypatch, fake):
@@ -45,23 +41,23 @@ def _patch_client(monkeypatch, fake):
 
 
 @pytest.mark.asyncio
-async def test_all_tools_registered():
-    mcp = create_mcp_server()
+async def test_all_tools_registered(settings):
+    mcp = create_mcp_server(settings)
     async with Client(mcp) as client:
         names = {tool.name for tool in await client.list_tools()}
     assert EXPECTED_TOOLS.issubset(names)
 
 
 @pytest.mark.asyncio
-async def test_destructive_action_blocked_by_default():
-    mcp = create_mcp_server()
+async def test_destructive_action_blocked_by_default(settings):
+    mcp = create_mcp_server(settings)
     async with Client(mcp) as client:
         result = await client.call_tool("add_bookmark", {"url": "https://example.com"})
     assert "Destructive actions are disabled" in result.content[0].text
 
 
 @pytest.mark.asyncio
-async def test_list_tags_happy_path(monkeypatch):
+async def test_list_tags_happy_path(monkeypatch, settings):
     class FakeClient:
         async def get_tags(self, limit, offset):
             return TagList(
@@ -72,15 +68,15 @@ async def test_list_tags_happy_path(monkeypatch):
             )
 
     _patch_client(monkeypatch, FakeClient())
-    mcp = create_mcp_server()
+    mcp = create_mcp_server(settings)
     async with Client(mcp) as client:
         result = await client.call_tool("list_tags", {"limit": 10})
     assert '"name": "python"' in result.content[0].text
 
 
 @pytest.mark.asyncio
-async def test_list_tags_validates_limit():
-    mcp = create_mcp_server()
+async def test_list_tags_validates_limit(settings):
+    mcp = create_mcp_server(settings)
     async with Client(mcp) as client:
         result = await client.call_tool("list_tags", {"limit": 0})
     assert "limit must be between 1 and 1000" in result.content[0].text


### PR DESCRIPTION
## Summary
Issue #5: the global `_settings` singleton (`get_settings()`/`reset_settings()`) created hidden global state and forced tests to reset between cases.

This removes the singleton entirely:
- `config.py` — dropped `_settings`, `get_settings()`, `reset_settings()`.
- `tools.py` — `create_mcp_server(settings: Settings)` now takes settings as a parameter and threads it through `register_tools` to every tool.
- `server.py` — `main()` constructs `Settings()` explicitly and injects it.

## Tests
- Replaced singleton tests with `TestDependencyInjection` (no global accessor, independent instances, explicit overrides). Tests no longer reset global state.
- `python -m pytest -q` → **81 passed**.
- `ruff check` → clean.

> CI note: 0 GitHub runner budget — merging without CI.

Closes #5